### PR TITLE
An alternative implementation of condition evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,23 @@ could be set for any Safe. The condition to check is then programmed
 by using a simple expression that consists of addresses of owners,
 signers, address constants, and boolean and arithmetic expressions.
 
-The expression is defined as bytecode of a simple stack VM.
+The expression is represented by an EVM code deployed as a separate
+contract.  Importantly, this code is sanitized by the guard before
+being deployed, so that we have a guarantee that it can do nothing
+other than its intended purpose:
 
+ - It can access memory, stack, storage.
+ - It *cannot* make any calls.
+ - It can access CALLDATA, so it will see any arguments passed to it.
+ - JUMP/JUMPI is supported, thus conditions of any complexity are possible.
 
-## Expressions
-
-The opcodes are generated from simple arithmetic expressions with syntax TBD.
 
 ## Lockout prevention
 
-The plan is to be able to statically verify that a given condition
-leaves an opportunity for a valid set of Safe signers to disable the
-Guard, if they choose so.  Because the VM opcode langauge is simple
-and deliberately non-turing complete, it will always be possible to
-guarantee correct verfication of Safe state after transaction and
-ability to disable the guard.
+TBD
 
-Note: some users might choose to ignore this, either because they have
-high confidence in their expression or becuase they have set up Safe
-recovery.
+Lockout prevention is more difficult in an EVM-based
+implementation, but is still possible. We can do best effort symbolic
+compuation on it (client-side), and if we are able to give a
+conclusive answer, we'll give it. If we are not able to do this, we'll
+warn the user before deploying the contract.

--- a/contracts/Guard.sol
+++ b/contracts/Guard.sol
@@ -322,6 +322,7 @@ contract EasyGuard is
 
                 // If it is an invalid
                 if ((info & VALID_OPCODE) == 0) {
+                    console.log("Disallowed or invalid opcode");
                     return false;
                 }
                 


### PR DESCRIPTION
https://x.com/valeryz/status/1899741967489065049

1. EVM itself will be evaluating the conditions.
2. EVM conditions are just EVM bytecode snippets.
3. Only contracts that we deploy ourselves could be used for checking conditions.
4. And we verify the bytecode before deploying it.
5. Each snippet must not do anything weird - it can only compute from memory/stack and calldata, which will have:
    - transaction details
    - signers
    - owners
6. This, snippets could be written in Solidity, as a fallback function of a contract. The tooling we use needs to extract just the function implementation.
7. JUMP/JUMPI are allowed, so it is perfectly fine to have complicated conditions.  The verification of the bytecode can handle the conditions. 
8. If anything other than simple PUSH* before JUMP/JUMPI is used, the verification will fail.


One key detail to understand this PR:

We are using BFS (https://en.wikipedia.org/wiki/Breadth-first_search) to walk through chunks of bytecode.  EVM bytecode is executed instruction after instruction, each one occupying one byte, except the PUSH* instructions.  BFS means that we have a queue of chunks to review.  Once we run into a JUMPI instruction, we add one more chunk to the queue.  Once we run into JUMP instruction, we will change the chunk we are looking at, but it will not lead to a branching, so no update to  the queue.

To verify a given opcode, we need to check whether it is allowed.  Two more things we need to do for each opcode, is define what it pushes to the stack, and how much it removes from the stack.  The reason for this, is that ahead of each JUMP / JUMPI instruction we need to know where to jump.  So we don't do full evaluation of each opcode (this would implemeting EVM in EVM - an interesting thing, but an overkill),  but we do a minimal evaluation of each opcode w.r.t. its effect on the stack, and we propagate constants through the stack (so that we have them for our JUMP/JUMPI instructions).  

To support this type of code walking, we need to store for every opcode whether it is allowed (1 bit should suffice), and how much it pushes to the stack (1 bit is enough for that), and how much it pops from the stack (2 bits are enough). This is what we store in the opcode table.
